### PR TITLE
SB-49 : Added PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,40 @@
+# Description
+
+Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Jira Issue [#SB-XX](https://app.clickup.com/t/86cykwjq0)
+
+- Please update the ticket link
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Chore (not feature-related, CI, repo or versioning)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# How Has This Been Tested?
+
+Please describe the tests that you ran to verify your changes.
+Provide instructions so we can reproduce.
+Please also list any relevant details for your test configuration
+
+- [ ] Test A
+- [ ] Test B
+
+**Test Configuration**:
+
+- architecture:
+
+# Checklist:
+
+- [ ] I Have mentioned in the title of the PR the related Jira Issue
+- [ ] I have performed a self-review of my code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added unit tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes


### PR DESCRIPTION
# Description

This PR introduces a GitHub Pull Request Template to the repository to standardize and improve the quality of PR descriptions. It helps contributors follow a consistent structure while submitting pull requests, ensuring that important details such as the purpose of the PR, testing information, and related tickets are clearly communicated.

Fixes: SB-49

Jira Issue [#SB-49](https://app.clickup.com/t/86cymvvwq)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Chore (not feature-related, CI, repo or versioning)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

# How Has This Been Tested?

Created a .github/pull_request_template.md file with a structured format.Pushed to the repository and verified that the template appears automatically when creating a PR via the GitHub UI.

- architecture: Mac M1

# Checklist:

- [x] I Have mentioned in the title of the PR the related Jira Issue
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added unit tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
