### PR TITLE
SB-70 : add filter to department

### DIFF
--- a/src/controllers/departmentController.ts
+++ b/src/controllers/departmentController.ts
@@ -6,6 +6,7 @@ import {
   HTTP_STATUS_OK,
   HTTP_STATUS_NOT_FOUND,
 } from '@constants/constants';
+import { Prisma } from '@prisma/client';
 import DepartmentService from '@services/departmentService';
 import { logger } from '@services/logService';
 import { departmentSchema } from '@utils/validations/department.schema';
@@ -77,7 +78,31 @@ export class DepartmentController {
     }
   };
 
-  public updateDepartment = async (req: Request, res: Response): Promise<void > => {
+  public getDepartmentsByFilter = async (req: Request, res: Response): Promise<void> => {
+    try {
+      const { name, collegeId } = req.query;
+
+      const filter: any = {};
+      if (name) filter.name = name;
+      if (collegeId) filter.collegeId = collegeId;
+
+      logger.info('[DepartmentController] Fetching departments with filter:', filter);
+
+      const departments = await this.departmentService.getDepartmentsByFilter(filter);
+
+      res.status(HTTP_STATUS_OK).json({ departments });
+    } catch (error) {
+      logger.error('[DepartmentController] Error fetching departments:', error);
+      res.status(HTTP_STATUS_INTERNAL_SERVER_ERROR).json({
+        message: 'Failed to fetch departments',
+        error: (error as Error).message,
+      });
+    }
+  };
+
+
+
+  public updateDepartment = async (req: Request, res: Response): Promise<void> => {
     const { id } = req.params;
     const updateFields = req.body;
 

--- a/src/dao/departmentDAO.ts
+++ b/src/dao/departmentDAO.ts
@@ -1,4 +1,4 @@
-import { PrismaClient, Department } from '@prisma/client';
+import { PrismaClient, Department, Prisma } from '@prisma/client';
 import { logger } from '../services/logService';
 
 const prisma = new PrismaClient();
@@ -38,6 +38,23 @@ const DepartmentDAO = {
       throw error;
     }
   },
+
+  getDepartmentsByFilter: async (filter: Record<string, any> = {}): Promise<Department[]> => {
+    try {
+      logger.info('[DepartmentDAO] Fetching departments with filter:', filter);
+      const departments = await prisma.department.findMany({
+        where: filter,
+        include: { college: true },
+      });
+      logger.info(`[DepartmentDAO] Fetched ${departments.length} departments`);
+      return departments;
+    } catch (error) {
+      logger.error('[DepartmentDAO] Error fetching departments:', error);
+      throw error;
+    }
+  },
+
+
 
   updateDepartment: async (id: string, updateFields: Partial<Department>): Promise<Department | null> => {
     try {

--- a/src/routes/departmentRoutes.ts
+++ b/src/routes/departmentRoutes.ts
@@ -6,6 +6,8 @@ export const departmentRouter = Router();
 
 departmentRouter.post('/', departmentController.createDepartment);
 departmentRouter.get('/', departmentController.getDepartments);
+departmentRouter.get('/filter', departmentController.getDepartmentsByFilter);
 departmentRouter.get('/:id', departmentController.getDepartmentById);
 departmentRouter.put('/:id', departmentController.updateDepartment);
 departmentRouter.delete('/:id', departmentController.deleteDepartment);
+

--- a/src/services/departmentService.ts
+++ b/src/services/departmentService.ts
@@ -1,5 +1,5 @@
 import DepartmentDAO from '@dao/departmentDAO';
-import { Department } from '@prisma/client';
+import { Department, Prisma } from '@prisma/client';
 import { ZodError } from 'zod';
 import { PrismaClient } from '@prisma/client';
 import { logger } from './logService';
@@ -14,7 +14,7 @@ class DepartmentService {
   }): Promise<{ department?: Department; error?: string }> {
     try {
       logger.info('[DepartmentService] Validating department creation input');
-      
+
 
       logger.info(`[DepartmentService] Checking if college ID=${params.collegeId} exists`);
       const college = await prisma.college.findUnique({ where: { id: params.collegeId } });
@@ -42,6 +42,13 @@ class DepartmentService {
     logger.info(`[DepartmentService] Getting department by ID=${id}`);
     return DepartmentDAO.getDepartmentById(id);
   }
+
+  public async getDepartmentsByFilter(filter: Record<string, any> = {}): Promise<Department[]> {
+    logger.info('[DepartmentService] Getting departments with filter:', filter);
+    return DepartmentDAO.getDepartmentsByFilter(filter);
+  }
+
+
 
   public async updateDepartment(
     id: string,


### PR DESCRIPTION
# Description

Implement filters to department 

Jira Issue [#SB-70](https://app.clickup.com/t/86cyvtkpg)

This PR implements filtering capabilities for fetching departments based on query parameters. It allows clients to retrieve department records by specifying fields such as `name` and `collegeId` as filters via URL parameters.

The filtering logic ensures:
- Query parameters are validated and sanitized.
- Only valid filter fields are processed.
- Departments are returned along with their associated college data.

You can test using postman:

Example: GET {{BASE_URL}}/department/filter?name=CSE&collegeId=a3c119de-919a-44fb-9081-451b0fbef1d1


## Type of change


- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [X] Chore (not feature-related, CI, repo or versioning)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update


# Checklist:

- [X] I Have mentioned in the title of the PR the related Jira Issue
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

